### PR TITLE
Maven3 compatibility

### DIFF
--- a/examples/extension/config/pom.xml
+++ b/examples/extension/config/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/extension/ear/pom.xml
+++ b/examples/extension/ear/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/extension/jar/pom.xml
+++ b/examples/extension/jar/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/extension/pom.xml
+++ b/examples/extension/pom.xml
@@ -25,6 +25,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>exo.portal.sample.extension.root</artifactId>

--- a/examples/extension/war/pom.xml
+++ b/examples/extension/war/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 	
   <modelVersion>4.0.0</modelVersion>

--- a/examples/portal/config/pom.xml
+++ b/examples/portal/config/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/portal/ear/pom.xml
+++ b/examples/portal/ear/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/portal/jar/pom.xml
+++ b/examples/portal/jar/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 
   <modelVersion>4.0.0</modelVersion>

--- a/examples/portal/pom.xml
+++ b/examples/portal/pom.xml
@@ -25,6 +25,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>exo.portal.sample.portal.root</artifactId>

--- a/examples/portal/rest-war/pom.xml
+++ b/examples/portal/rest-war/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 	
   <modelVersion>4.0.0</modelVersion>

--- a/examples/portal/war/pom.xml
+++ b/examples/portal/war/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
   </parent> 
 	
   <modelVersion>4.0.0</modelVersion>

--- a/examples/portlets/pom.xml
+++ b/examples/portlets/pom.xml
@@ -6,6 +6,7 @@
       <groupId>org.exoplatform.portal</groupId>
       <artifactId>exo.portal.parent</artifactId>
       <version>3.1.6-REBASED-SNAPSHOT</version>
+      <relativePath>../../pom.xml</relativePath>
    </parent>
 
    <groupId>org.gatein.portal.examples.portlets</groupId>

--- a/examples/skins/pom.xml
+++ b/examples/skins/pom.xml
@@ -6,6 +6,7 @@
       <groupId>org.exoplatform.portal</groupId>
       <artifactId>exo.portal.parent</artifactId>
       <version>3.1.6-REBASED-SNAPSHOT</version>
+      <relativePath>../../pom.xml</relativePath>
    </parent>
 
    <groupId>org.gatein.portal.examples.skins</groupId>

--- a/starter/ear/pom.xml
+++ b/starter/ear/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/starter/war/pom.xml
+++ b/starter/war/pom.xml
@@ -24,6 +24,7 @@
     <groupId>org.exoplatform.portal</groupId>
     <artifactId>exo.portal.parent</artifactId>
     <version>3.1.6-REBASED-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent> 
 	
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This changes in POMs are required to build with Maven3. See : https://cwiki.apache.org/MAVEN/maven-3x-compatibility-notes.html#Maven3.xCompatibilityNotes-ParentPOMResolution
