### PR TITLE
EXOGTN-1284: Incorrect warning message of configured UI data validators

### DIFF
--- a/component/web/controller/src/main/java/org/exoplatform/web/application/ApplicationMessage.java
+++ b/component/web/controller/src/main/java/org/exoplatform/web/application/ApplicationMessage.java
@@ -23,6 +23,7 @@
 package org.exoplatform.web.application;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /** @author <a href="mailto:chris.laprun@jboss.com">Chris Laprun</a> */
 public class ApplicationMessage extends AbstractApplicationMessage implements Serializable
@@ -42,7 +43,36 @@ public class ApplicationMessage extends AbstractApplicationMessage implements Se
       this.messageArgs_ = args;
       setType(type);
    }
+   
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
+    ApplicationMessage that = (ApplicationMessage) o;
+
+    if (!Arrays.equals(messageArgs_, that.messageArgs_)) {
+      return false;
+    }
+    if (!messageKey_.equals(that.messageKey_)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = messageKey_.hashCode();
+    result = 31 * result
+        + (messageArgs_ != null ? Arrays.hashCode(messageArgs_) : 0);
+    return result;
+  }
+   
    public String getMessageKey()
    {
       return messageKey_;

--- a/component/web/controller/src/main/java/org/exoplatform/web/application/CompoundApplicationMessage.java
+++ b/component/web/controller/src/main/java/org/exoplatform/web/application/CompoundApplicationMessage.java
@@ -23,14 +23,14 @@
 package org.exoplatform.web.application;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.ResourceBundle;
 
 /** @author <a href="mailto:chris.laprun@jboss.com">Chris Laprun</a> */
 public class CompoundApplicationMessage extends AbstractApplicationMessage implements Serializable
 {
-   private List<AbstractApplicationMessage> messages = new ArrayList<AbstractApplicationMessage>(5);
+   private Set<AbstractApplicationMessage> messages = new HashSet<AbstractApplicationMessage>(5);
 
    public CompoundApplicationMessage()
    {
@@ -70,7 +70,9 @@ public class CompoundApplicationMessage extends AbstractApplicationMessage imple
 
    public void addMessage(String messageKey, Object[] args)
    {
-      messages.add(new ApplicationMessage(messageKey, args, AbstractApplicationMessage.WARNING));
+ 	   final ApplicationMessage message = new ApplicationMessage(messageKey, args, AbstractApplicationMessage.WARNING);
+ 	   message.setArgsLocalized(false);
+ 	   messages.add(message);
    }
 
    public boolean isEmpty()

--- a/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIGroupMembershipForm.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/UIGroupMembershipForm.java
@@ -42,7 +42,7 @@ import org.exoplatform.webui.event.EventListener;
 import org.exoplatform.webui.form.UIForm;
 import org.exoplatform.webui.form.UIFormSelectBox;
 import org.exoplatform.webui.form.UIFormStringInput;
-import org.exoplatform.webui.form.validator.UserConfigurableValidator;
+import org.exoplatform.webui.form.validator.MandatoryValidator;
 import org.exoplatform.webui.organization.account.UIUserSelector;
 
 import java.util.ArrayList;
@@ -81,7 +81,7 @@ public class UIGroupMembershipForm extends UIForm
       /*addUIFormInput(new UIFormStringInput(USER_NAME, USER_NAME, null).addValidator(MandatoryValidator.class)
          .addValidator(ExpressionValidator.class, "^\\p{L}[\\p{L}\\d._\\-\\s*,\\s*]+$",
             "UIGroupMembershipForm.msg.Invalid-char"));*/
-      addUIFormInput(new UIFormStringInput(USER_NAME, USER_NAME, null).addValidator(UserConfigurableValidator.class, UserConfigurableValidator.GROUPMEMBERSHIP, UserConfigurableValidator.GROUP_MEMBERSHIP_LOCALIZATION_KEY));
+      addUIFormInput(new UIFormStringInput(USER_NAME, USER_NAME, null).addValidator(MandatoryValidator.class));
       addUIFormInput(new UIFormSelectBox("membership", "membership", listOption).setSize(1));
       UIPopupWindow searchUserPopup = addChild(UIPopupWindow.class, "SearchUser", "SearchUser");
       searchUserPopup.setWindowSize(640, 0);


### PR DESCRIPTION
Problem analysis
    - Several messages are duplicated if username has more than 2 illegal characters.
    - Username configuration accepts still uppercase characters by default.
    - In case gatein.validators.{configurationName}.format.message has a point, only the part after the last point is defined as message

Fix description
    - For each invalid condition of username, only add a message
    - Correct behaviour to forbid uppercase characters
    - Get all characters of format.message value
