### PR TITLE
EXOGTN-1289: PicketLink : membership duplication

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/Config.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/Config.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
 /*
  * @author <a href="mailto:boleslaw.dawidowicz at redhat.com">Boleslaw Dawidowicz</a>
@@ -50,7 +52,7 @@ public class Config
 
    private String associationMembershipType;
 
-   private boolean ignoreMappedMembershipType = true;
+   private List<String> ignoreMappedMembershipTypeGroupList = new ArrayList<String>();
 
    private boolean useJTA = false;
 
@@ -59,6 +61,8 @@ public class Config
    private boolean sortMemberships = true;
 
    private boolean countPaginatedUsers = true;
+
+   private boolean skipPaginationInMembershipQuery = false;
 
    public Config()
    {
@@ -160,6 +164,28 @@ public class Config
 
       return null;
    }
+   
+  public boolean isIgnoreMappedMembershipTypeForGroup(String groupId) {
+    if ("/".equals(groupId)) {
+      return false;
+    }
+    String parentId = groupId.substring(0, groupId.lastIndexOf("/"));
+    for (String id : ignoreMappedMembershipTypeGroupList) {
+      // Check if any mapping that contains '/*' match this id
+      if (id.endsWith("/*")) {
+        id = id.substring(0, id.length() - 2);
+        // Check exact equality case
+      } else if (id.equals(groupId)) {
+        return true;
+      } else {
+        continue;
+      }
+      if (parentId.startsWith(id)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
    public String getPLIDMGroupName(String gtnGroupName)
    {
@@ -281,15 +307,14 @@ public class Config
       this.associationMembershipType = associationMembershipType;
    }
 
-   public boolean isIgnoreMappedMembershipType()
-   {
-      return ignoreMappedMembershipType;
-   }
+  public List<String> getIgnoreMappedMembershipTypeGroupList()
+  {
+    return this.ignoreMappedMembershipTypeGroupList;
+  }
 
-   public void setIgnoreMappedMembershipType(boolean ignoreMappedMembershipType)
-   {
-      this.ignoreMappedMembershipType = ignoreMappedMembershipType;
-   }
+  public void setIgnoreMappedMembershipTypeGroupList(List<String> ignoreMappedMembershipTypeGroupList) {
+    this.ignoreMappedMembershipTypeGroupList = ignoreMappedMembershipTypeGroupList;
+  }
 
    public boolean isUseJTA()
    {
@@ -340,4 +365,14 @@ public class Config
    {
       this.countPaginatedUsers = countPaginatedUsers;
    }
+
+  public boolean isSkipPaginationInMembershipQuery()
+  {
+    return skipPaginationInMembershipQuery;
+  }
+
+  public void setSkipPaginationInMembershipQuery(boolean skipPaginationInMembershipQuery)
+  {
+    this.skipPaginationInMembershipQuery = skipPaginationInMembershipQuery;
+  }
 }

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -341,10 +341,11 @@ public class GroupDAOImpl implements GroupHandler
 
       for (org.picketlink.idm.api.Role role : allRoles)
       {
-         if (mmm.isCreateMembership(role.getRoleType().getName()))                            
-         {
-            exoGroups.add(convertGroup(role.getGroup()));
-         }
+        Group exoGroup = convertGroup(role.getGroup());
+        if (mmm.isCreateMembership(role.getRoleType().getName(), exoGroup.getId()))
+        {
+          exoGroups.add(exoGroup);
+        }
       }
 
       if (mmm.isAssociationMapped() && mmm.getAssociationMapping().equals(membershipType))
@@ -1181,7 +1182,4 @@ public class GroupDAOImpl implements GroupHandler
    {
       return orgService.getConfiguration().getGtnGroupName(plidmGroupName);
    }
-
-
-
 }

--- a/component/identity/src/test/resources/org/exoplatform/services/organization/TestOrganizationService-configuration.xml
+++ b/component/identity/src/test/resources/org/exoplatform/services/organization/TestOrganizationService-configuration.xml
@@ -140,11 +140,18 @@
           <field name="associationMembershipType">
             <string>member</string>
           </field>
-          <!-- if "associationMembershipType" option is used and this option is set to true
-                then Membership with MembershipType configured to be stored as PicketLink IDM association
-                will not be stored as PicketLink IDM Role -->
-          <field name="ignoreMappedMembershipType">
-            <boolean>false</boolean>
+          <field name="ignoreMappedMembershipTypeGroupList">
+           <collection type="java.util.ArrayList" item-type="java.lang.String">
+             <value>
+               <string>/platform/*</string>
+             </value>
+             <value>
+               <string>/organization/acme/france</string>
+             </value>
+             <value>
+               <string>/toto/*</string>
+             </value>
+           </collection>
           </field>
         </object>
       </object-param>

--- a/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/web/portal/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -218,9 +218,19 @@
           </field>
           <!-- if "associationMembershipType" option is used and this option is set to true
                 then Membership with MembershipType configured to be stored as PicketLink IDM association
-                will not be stored as PicketLink IDM Role -->
-          <field name="ignoreMappedMembershipType">
-            <boolean>false</boolean>
+                will not be stored as PicketLink IDM Role in case that they are in groups from this parameter.
+                For RW LDAP setup, it's recommended to map all groups mapped to LDAP (all those from parameter groupTypeMappings)
+                However for DB only and/or Read-only LDAP, it's recommended to not map anything here -->
+          <field name="ignoreMappedMembershipTypeGroupList">
+            <collection type="java.util.ArrayList" item-type="java.lang.String">
+              <!-- Uncomment for sample LDAP config
+              <value>
+                <string>/platform/*</string>
+              </value>
+              <value>
+                <string>/organization/*</string>
+              </value>-->
+            </collection>
           </field>
           <!-- If 'true' will use JTA UserTransaction. If 'false' will use IDM transaction API -->
           <field name="useJTA">
@@ -246,15 +256,30 @@
           <!-- For some LDAP configurations where part of users can duplicate in both DB and LDAP
                it is not possible to count user efficiently for paginated query. Only way is to download
                whole content of LDAP server and exclude duplicates manually to return accurate user count.
-               When this option is set to true GateIn will rely on user count information returned from PLIDM
+               When this option is set to false GateIn will rely on user count information returned from PLIDM
                which can return greater number of users then in real non duplicated count for perf reasons..
                Those users will be filtered before returning search page however to not return nulls last entry
                can be duplicated in returned user list.
-               If this value is set to false GateIn will perform whole non paginated query and filter it after.
-               It will result in more accurate results and paginated list size info however can affect performance -->
+               If this value is set to true GateIn will perform whole non paginated query and filter it after.
+               It will result in more accurate results and paginated list size info however can affect performance
+               If you have DB only setup, it's recommended to switch this option to false. This will help to have better performance.
+               If you have DB+LDAP setup, it's recommended to switch this option to true, otherwise you can have inaccurate results -->
           <field name="countPaginatedUsers">
             <boolean>true</boolean>
           </field>
+          <!-- For DB+LDAP it is not possible to efficiently perform paginated membership query. Only way is to download
+               all memberships from LDAP server and all memberships from DB and merge them together.
+               When this option is set to false GateIn will rely on membership count information returned from PLIDM
+               and it will use paginated membership queries based on this. This is better for performance but for DB+LDAP the
+               memberships pagination may not behave correctly.
+               If this value is set to true GateIn will perform whole non paginated query to obtain all memberships and filter it after.
+               It will result in more accurate results however can affect performance.
+               If you have DB only setup, it's recommended to switch this option to false. This will help to have better performance.
+               If you have DB+LDAP setup, it's recommended to switch this option to true, otherwise you can have inaccurate results -->
+          <field name="skipPaginationInMembershipQuery">
+            <boolean>true</boolean>
+          </field>
+          
         </object>
       </object-param>
     </init-params>


### PR DESCRIPTION
Problem analysis
    -  ignoreMappedMembershipType parameter which makes the mapping between "member" and "JBOSS_IDENTITY_MEMBERSHIP" doesn't work
        -  Because memberships can be obtained from DB and LDAP, the membership is duplicated

Fix description
    - Specify groups whose membership will ignore mapping
    - Provide parameter to skip storing membership in PLIDM which improves performance in case of not using LDAP
