### PR TITLE
EXOCONSULTING-135: "overwrite" import mode does not delete pages

### DIFF
--- a/component/portal/src/test/java/org/exoplatform/portal/config/AbstractSiteDataImportTest.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/AbstractSiteDataImportTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractSiteDataImportTest extends AbstractDataImportTest
    }
    
    @Override
-   protected final void afterOneBootWithExtention(PortalContainer container) throws Exception
+   protected void afterOneBootWithExtention(PortalContainer container) throws Exception
    {
       RequestLifeCycle.begin(container);
       

--- a/component/portal/src/test/java/org/exoplatform/portal/config/TestSiteDataImportOverwrite.java
+++ b/component/portal/src/test/java/org/exoplatform/portal/config/TestSiteDataImportOverwrite.java
@@ -25,8 +25,12 @@ import org.exoplatform.portal.config.model.Application;
 import org.exoplatform.portal.config.model.Container;
 import org.exoplatform.portal.config.model.Page;
 import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteType;
 import org.exoplatform.portal.mop.importer.ImportMode;
+import org.exoplatform.portal.mop.importer.Imported;
+import org.exoplatform.portal.pom.config.POMSessionManager;
 import org.exoplatform.portal.pom.spi.portlet.Portlet;
+import org.gatein.mop.api.workspace.Workspace;
 
 /**
  * @author <a href="trongtt@gmail.com">Trong Tran</a>
@@ -39,6 +43,52 @@ public class TestSiteDataImportOverwrite extends AbstractSiteDataImportTest
    protected ImportMode getMode()
    {
       return ImportMode.OVERWRITE;
+   }
+   @Override
+   protected void afterOneBootWithExtention(PortalContainer container) throws Exception
+   {
+     RequestLifeCycle.begin(container);
+     
+     POMSessionManager mgr = (POMSessionManager)container.getComponentInstanceOfType(POMSessionManager.class);
+     Workspace workspace = mgr.getSession().getWorkspace();
+     assertTrue(workspace.isAdapted(Imported.class));
+     
+     // Test portal
+     DataStorage dataStorage = (DataStorage)container.getComponentInstanceOfType(DataStorage.class);
+     PortalConfig portal = dataStorage.getPortalConfig("classic");
+     Container layout = portal.getPortalLayout();
+     assertEquals(1, layout.getChildren().size());
+     Application<Portlet> layoutPortlet = (Application<Portlet>)layout.getChildren().get(0);
+     assertEquals("site2/layout", dataStorage.getId(layoutPortlet.getState()));
+     
+     Page page = dataStorage.getPage("portal::classic::home");
+     assertNull(page);
+     
+     page = dataStorage.getPage("portal::classic::page1");
+     assertNotNull(page);
+     assertEquals("site 2", page.getTitle());
+     
+     page = dataStorage.getPage("portal::classic::page2");
+     assertNotNull(page);
+     assertEquals("site 2", page.getTitle());
+
+     // Test group
+     portal = dataStorage.getPortalConfig(SiteType.GROUP.getName(), "/platform/administrators");
+     layout = portal.getPortalLayout();
+     assertEquals(1, layout.getChildren().size());
+     layoutPortlet = (Application<Portlet>)layout.getChildren().get(0);
+     assertEquals("site1/layout", dataStorage.getId(layoutPortlet.getState()));
+     
+     page = dataStorage.getPage("group::/platform/administrators::page1");
+     assertNotNull(page);
+     assertEquals("site 2", page.getTitle());
+     
+     // Test user
+     Page dashboard1 = dataStorage.getPage("user::root::dashboard1");
+     assertNotNull(dashboard1);
+     assertEquals("site 2", dashboard1.getTitle());
+     
+     RequestLifeCycle.end();
    }
    
    @Override
@@ -56,9 +106,8 @@ public class TestSiteDataImportOverwrite extends AbstractSiteDataImportTest
       
       //
       Page home = dataStorage.getPage("portal::classic::home");
-      assertNotNull(home);
-      assertEquals("site 1", home.getTitle());
-
+      assertNull(home);
+      
       Page page1 = dataStorage.getPage("portal::classic::page1");
       assertNotNull(page1);
       assertEquals("site 2", page1.getTitle());


### PR DESCRIPTION
Description:
    - Change OVERWRITE import mode behavior for PageImporter
        + Only keep pages listed in pages.xml of portal and group
        + Update all user pages (in Dashboard)
