### PR TITLE
EXOGTN-1317: [IE] Backspace is equivalent to back button of web browser ...

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/DOMUtil.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/DOMUtil.js
@@ -466,26 +466,23 @@ DOMUtil.prototype.disableOnClick = function(el) {
 }
 
 /**
- * Disable BackspaceKey in unneccessary element
+ * Disable BackspaceKey in unneccessary element in IE
  *
  */
 DOMUtil.prototype.disableBackspaceKey = function() {
-  document.onkeydown = function (evt) {
-    var requiredElements = /INPUT|TEXTAREA/i;
-    if( evt.keyCode == 8 ) { // 8 == backspace
-      if (!requiredElements.test(evt.target.tagName) || evt.target.disabled || evt.target.readOnly ) {
-        if(navigator.appName == 'Microsoft Internet Explorer') { // Cancel bubble for ie
-          window.event.cancelBubble = true ;
-          window.event.returnValue = false ;
-          return ;
-        } else { // Cancel event for Firefox, Opera, Safari
-          event.stopPropagation() ;
-          event.preventDefault() ;
-        }
+  if(navigator.appName == 'Microsoft Internet Explorer') {
+    document.onkeydown = function (evt) {
+      evt = evt ||  window.event;
+      var keyCode = evt.keyCode;
+      if( keyCode == 8 && ( !evt.srcElement.isTextEdit || evt.srcElement.disabled || evt.srcElement.readOnly )  ) { // 8 == backspace
+        evt.cancelBubble = true ;
+        evt.returnValue = false ;
+        return false;
       }
-    }
-  };
+    };
+  }
 };
+
 
 /****************************************************************************/
 eXo.core.DOMUtil = new DOMUtil() ;

--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/DOMUtil.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/DOMUtil.js
@@ -22,6 +22,7 @@
  */
 function DOMUtil() {
 	this.hideElementList = new Array() ;
+        this.disableBackspaceKey();
 } ;
 /**
  * Returns true if elemt has the css class className
@@ -463,6 +464,28 @@ DOMUtil.prototype.get = function(el) {
 DOMUtil.prototype.disableOnClick = function(el) {
 	el.onclick = new Function("return false;");
 }
+
+/**
+ * Disable BackspaceKey in unneccessary element
+ *
+ */
+DOMUtil.prototype.disableBackspaceKey = function() {
+  document.onkeydown = function (evt) {
+    var requiredElements = /INPUT|TEXTAREA/i;
+    if( evt.keyCode == 8 ) { // 8 == backspace
+      if (!requiredElements.test(evt.target.tagName) || evt.target.disabled || evt.target.readOnly ) {
+        if(navigator.appName == 'Microsoft Internet Explorer') { // Cancel bubble for ie
+          window.event.cancelBubble = true ;
+          window.event.returnValue = false ;
+          return ;
+        } else { // Cancel event for Firefox, Opera, Safari
+          event.stopPropagation() ;
+          event.preventDefault() ;
+        }
+      }
+    }
+  };
+};
 
 /****************************************************************************/
 eXo.core.DOMUtil = new DOMUtil() ;


### PR DESCRIPTION
...in readonly/disable input field.

Problem analysis
    - Backspace in IE if cursor is not focused on input/textare field is equivalent to back button

Fix description
    - Prevent triggering backspace in IE if cursor is not focused on input/textare field
