### PR TITLE
EXOGTN-1259: Deleting a group causes IdentityException with LDAP (openLD...

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -284,6 +284,20 @@ public class GroupDAOImpl implements GroupHandler
             //TODO: impl force in IDM
             getIdentitySession().getPersistenceManager().removeGroup(child, true);
          }
+         // Obtain parents
+
+         Collection<org.picketlink.idm.api.Group> parents = 
+            getIdentitySession().getRelationshipManager().findAssociatedGroups(jbidGroup, null, false, false);
+
+         // not possible to disassociate only one child...
+         Set dummySet = new HashSet();
+         dummySet.add(jbidGroup);
+         
+         for (org.picketlink.idm.api.Group parent : parents)
+         {
+            getIdentitySession().getRelationshipManager().disassociateGroups(parent, dummySet);
+         }
+         
       }
       catch (Exception e)
       {


### PR DESCRIPTION
...AP or OpenDS)

Problem analysis
    - When a child group is removed, the relationship between it and its children is not deleted. As the result, LDAP cannot find the child node from the relation in parent group

Fix description
    - Remove relation between group and its parent when it will be deleted
