### PR TITLE
EXOGTN-1438: Restrict view of groups in organization portlet

### DIFF
--- a/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/GroupManagement.java
+++ b/portlet/exoadmin/src/main/java/org/exoplatform/organization/webui/component/GroupManagement.java
@@ -33,7 +33,7 @@ import java.util.List;
  * Created by The eXo Platform SAS
  * Author : Huu-Dung Kieu	
  *          kieuhdung@gmail.com
- * 22 déc. 08  
+ * 22 dÃ©c. 08  
  */
 public class GroupManagement
 {
@@ -119,7 +119,8 @@ public class GroupManagement
       String groupId = group.getId();
       for (Object g : groups)
       {
-         if (((Group)g).getId().startsWith(groupId))
+         String groupIdElement = ((Group)g).getId(); 
+         if (groupIdElement.equalsIgnoreCase(groupId) || (groupIdElement.matches("^" + groupId + "/.*" )))
          {
             ret = true;
             break;


### PR DESCRIPTION
Problem analysis:
    - Suppose a user who is an administrator and he is a manager of a group e.g. A. All groups whose ID is prefix of ID of A will be listed in Group Management if user logins.

Fix description
    - Match only parent group with its children or itself.
