### PR TITLE
EXOGTN-1704: Hibernate session leak with idm database

### DIFF
--- a/component/web/security/src/main/java/org/exoplatform/web/CacheUserProfileFilter.java
+++ b/component/web/security/src/main/java/org/exoplatform/web/CacheUserProfileFilter.java
@@ -64,8 +64,13 @@ public class CacheUserProfileFilter extends AbstractFilter
                   (OrganizationService)getContainer().getComponentInstanceOfType(OrganizationService.class);
 
                begin(orgService);
-               User user = orgService.getUserHandler().findUserByName(state.getIdentity().getUserId());
-               end(orgService);
+               User user = null;
+               try {
+                   user = orgService.getUserHandler().findUserByName(state.getIdentity().getUserId());
+               }
+               finally {
+                   end(orgService);
+               }
                state.setAttribute(USER_PROFILE, user);
             }
 


### PR DESCRIPTION
Fix description:
- Ending the request lifecycle should be added to the finally bloc to be always executed even if an exception is encountered
