### PR TITLE
Fix/3.2.x/exogtn 1805 | IDM DAO classes are only catching IdentityExceptions

### DIFF
--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/GroupDAOImpl.java
@@ -150,7 +150,7 @@ public class GroupDAOImpl implements GroupHandler
          catch (Exception e)
          {
             log.info("Cannot obtain group: " + parentPLGroupName, e);
-
+            orgService.recoverFromIDMError();
          }
 
          ((ExtGroup)child).setId(parent.getId() + "/" + child.getGroupName());
@@ -187,6 +187,7 @@ public class GroupDAOImpl implements GroupHandler
       catch (Exception e)
       {
          log.info("Cannot associate groups: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (broadcast)
@@ -258,6 +259,7 @@ public class GroupDAOImpl implements GroupHandler
       catch (Exception e)
       {
          log.info("Cannot obtain group: " + plGroupName + "; ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (jbidGroup == null)
@@ -288,6 +290,7 @@ public class GroupDAOImpl implements GroupHandler
       catch (Exception e)
       {
          log.info("Cannot clear group relationships: " + plGroupName + "; ", e);
+         orgService.recoverFromIDMError();
       }
 
       try
@@ -298,6 +301,7 @@ public class GroupDAOImpl implements GroupHandler
       catch (Exception e)
       {
          log.info("Cannot remove group: " + plGroupName + "; ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (broadcast)
@@ -333,6 +337,7 @@ public class GroupDAOImpl implements GroupHandler
       catch (Exception e)
       {
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       Set<Group> exoGroups = new HashSet<Group>();
@@ -361,6 +366,7 @@ public class GroupDAOImpl implements GroupHandler
          catch (Exception e)
          {
             log.info("Identity operation error: ", e);
+            orgService.recoverFromIDMError();
          }
 
          for (org.picketlink.idm.api.Group group : groups)
@@ -469,7 +475,7 @@ public class GroupDAOImpl implements GroupHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
       }
 
@@ -494,7 +500,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       // Get members of all types mapped below the parent group id path.
@@ -514,6 +520,7 @@ public class GroupDAOImpl implements GroupHandler
             {
                //TODO:
                log.info("Identity operation error: ", e);
+               orgService.recoverFromIDMError();
             }
          }
       }
@@ -624,7 +631,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       List<Group> exoGroups = new LinkedList<Group>();
@@ -675,7 +682,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       // Check for all type groups mapped as part of the group tree but not connected with the root group by association
@@ -692,6 +699,7 @@ public class GroupDAOImpl implements GroupHandler
             {
                //TODO:
                log.info("Identity operation error: ", e);
+               orgService.recoverFromIDMError();
             }
          }
       }
@@ -784,6 +792,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       String gtnGroupName = getGtnGroupName(jbidGroup.getName());
@@ -909,6 +918,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       // Check if there is cross reference so we ended in a loop and break the process.
@@ -1029,6 +1039,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (jbidGroup == null)
@@ -1043,6 +1054,7 @@ public class GroupDAOImpl implements GroupHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
+            orgService.recoverFromIDMError();
          }
       }
 
@@ -1074,6 +1086,7 @@ public class GroupDAOImpl implements GroupHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
+            orgService.recoverFromIDMError();
          }
 
       }
@@ -1151,6 +1164,7 @@ public class GroupDAOImpl implements GroupHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (rootGroup == null)
@@ -1167,6 +1181,7 @@ public class GroupDAOImpl implements GroupHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
+            orgService.recoverFromIDMError();
          }
       }
 

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipDAOImpl.java
@@ -237,7 +237,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (hasRole)
@@ -261,7 +261,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
       }
       if (isAssociationMapped() && getAssociationMapping().equals(m.getMembershipType()))
@@ -274,7 +274,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
       }
 
@@ -319,7 +319,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       boolean associated = false;
@@ -332,6 +332,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (!hasRole &&
@@ -356,7 +357,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
       }
 
@@ -372,7 +373,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
       }
 
@@ -411,7 +412,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       HashSet<MembershipImpl> memberships = new HashSet<MembershipImpl>();
@@ -452,7 +453,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
 
          Set<String> keys = new HashSet<String>();
@@ -468,7 +469,7 @@ public class MembershipDAOImpl implements MembershipHandler
             {
                //TODO:
                log.info("Identity operation error: ", e);
-
+               orgService.recoverFromIDMError();
             }
          }
 
@@ -516,7 +517,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (isAssociationMapped() && getAssociationMapping().equals(type) && associated)
@@ -535,7 +536,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (role != null &&
@@ -621,7 +622,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       HashSet<MembershipImpl> memberships = new HashSet<MembershipImpl>();
@@ -648,7 +649,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (isAssociationMapped() && associated)
@@ -702,7 +703,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       HashSet<MembershipImpl> memberships = new HashSet<MembershipImpl>();
@@ -733,7 +734,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
 
          for (org.picketlink.idm.api.Group group : groups)
@@ -831,7 +832,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       HashSet<MembershipImpl> memberships = new HashSet<MembershipImpl>();
@@ -863,7 +864,7 @@ public class MembershipDAOImpl implements MembershipHandler
          {
             //TODO:
             log.info("Identity operation error: ", e);
-
+            orgService.recoverFromIDMError();
          }
 
          for (org.picketlink.idm.api.User user : users)
@@ -945,7 +946,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       try
@@ -970,7 +971,7 @@ public class MembershipDAOImpl implements MembershipHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (log.isTraceEnabled())

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipTypeDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipTypeDAOImpl.java
@@ -32,7 +32,13 @@ import org.picketlink.idm.api.RoleType;
 
 import java.text.DateFormat;
 import java.text.ParseException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 /*
  * @author <a href="mailto:boleslaw.dawidowicz at redhat.com">Boleslaw Dawidowicz</a>

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipTypeDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/MembershipTypeDAOImpl.java
@@ -32,12 +32,7 @@ import org.picketlink.idm.api.RoleType;
 
 import java.text.DateFormat;
 import java.text.ParseException;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /*
  * @author <a href="mailto:boleslaw.dawidowicz at redhat.com">Boleslaw Dawidowicz</a>
@@ -119,7 +114,15 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
          preSave(mt, true);
       }
 
-      getIdentitySession().getRoleManager().createRoleType(mt.getName());
+      try
+      {
+         getIdentitySession().getRoleManager().createRoleType(mt.getName());
+      }
+      catch (Exception e)
+      {
+         log.info("Error when creating Membership", e);
+         orgService.recoverFromIDMError();
+      }
 
       if (broadcast)
       {
@@ -178,7 +181,16 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
          );
       }
 
-      RoleType rt = getIdentitySession().getRoleManager().getRoleType(name);
+      RoleType rt = null;
+      try
+      {
+         rt = getIdentitySession().getRoleManager().getRoleType(name);
+      }
+      catch (Exception e)
+      {
+         log.info("Identity error when finding membership type " + name, e);
+         orgService.recoverFromIDMError();
+      }
 
       MembershipType mt = null;
 
@@ -226,7 +238,15 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
             preDelete(mt);
          }
 
-         getIdentitySession().getRoleManager().removeRoleType(mt.getName());
+        try
+        {
+           getIdentitySession().getRoleManager().removeRoleType(mt.getName());
+        }
+        catch (Exception e)
+        {
+           log.info("Error occured when removing membership type", e);
+           orgService.recoverFromIDMError();
+        }
 
          if (broadcast)
          {
@@ -251,7 +271,16 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
          );
       }
 
-      Collection<RoleType> rts = getIdentitySession().getRoleManager().findRoleTypes();
+      Collection<RoleType> rts = Collections.EMPTY_LIST;
+      try
+      {
+         rts = getIdentitySession().getRoleManager().findRoleTypes();
+      }
+      catch (Exception e)
+      {
+         log.info("Exception occured when looking for membership type", e);
+         orgService.recoverFromIDMError();
+      }
 
       List<MembershipType> mts = new LinkedList<MembershipType>();
 
@@ -282,8 +311,17 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
 
    private void updateMembershipType(MembershipType mt) throws Exception
    {
-
-      RoleType rt = getIdentitySession().getRoleManager().getRoleType(mt.getName());
+      RoleType rt;
+      try
+      {
+         rt = getIdentitySession().getRoleManager().getRoleType(mt.getName());
+      }
+      catch (Exception e)
+      {
+         log.info("Exception occured when finding role type", e);
+         orgService.recoverFromIDMError();
+         return;
+      }
 
       Map<String, String> props = new HashMap<String, String>();
 
@@ -293,7 +331,15 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
          .put(MEMBERSHIP_MODIFIED_DATE, mt.getModifiedDate() == null ? null : "" + mt.getModifiedDate().getTime());
       props.put(MEMBERSHIP_OWNER, mt.getOwner());
 
-      getIdentitySession().getRoleManager().setProperties(rt, props);
+      try
+      {
+         getIdentitySession().getRoleManager().setProperties(rt, props);
+      }
+      catch (Exception e)
+      {
+         log.info("Exception when updating membership type", e);
+         orgService.recoverFromIDMError();
+      }
 
       return;
 
@@ -301,9 +347,18 @@ public class MembershipTypeDAOImpl implements MembershipTypeHandler
 
    private void populateMembershipType(MembershipType mt) throws Exception
    {
-      RoleType rt = getIdentitySession().getRoleManager().getRoleType(mt.getName());
-
-      Map<String, String> props = getIdentitySession().getRoleManager().getProperties(rt);
+      Map<String, String> props;
+      try
+      {
+         RoleType rt = getIdentitySession().getRoleManager().getRoleType(mt.getName());
+         props =  getIdentitySession().getRoleManager().getProperties(rt);
+      }
+      catch (Exception e)
+      {
+          log.info("Identity error occured when populating membership type", e);
+          orgService.recoverFromIDMError();
+          return;
+      }
 
       mt.setDescription(props.get(MEMBERSHIP_DESCRIPTION));
       mt.setOwner(props.get(MEMBERSHIP_OWNER));

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserDAOImpl.java
@@ -33,7 +33,6 @@ import org.picketlink.idm.api.Attribute;
 import org.picketlink.idm.api.AttributesManager;
 import org.picketlink.idm.api.IdentitySession;
 import org.picketlink.idm.api.query.UserQueryBuilder;
-import org.picketlink.idm.common.exception.IdentityException;
 import org.picketlink.idm.impl.api.SimpleAttribute;
 import org.picketlink.idm.impl.api.model.SimpleUser;
 
@@ -161,10 +160,10 @@ public class UserDAOImpl implements UserHandler
 
          session.getPersistenceManager().createUser(user.getUserName());
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
          log.info("Identity operation error: ", e);
-         throw e;
+         orgService.recoverFromIDMError();
       }
 
       if (getIntegrationCache() != null)
@@ -172,11 +171,14 @@ public class UserDAOImpl implements UserHandler
          getIntegrationCache().invalidateAll();
       }
 
-      try {
+      try
+      {
           persistUserInfo(user, session);
-      } catch (IdentityException e) {
+      }
+      catch (Exception e)
+      {
           session.getPersistenceManager().removeUser(user.getUserName(),true);
-          throw e;
+          orgService.recoverFromIDMError();
       }
 
       if (broadcast)
@@ -242,10 +244,10 @@ public class UserDAOImpl implements UserHandler
 
          foundUser = session.getPersistenceManager().findUser(userName);
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
          log.info("Cannot obtain user: " + userName + "; ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (foundUser == null)
@@ -262,7 +264,7 @@ public class UserDAOImpl implements UserHandler
       catch (Exception e)
       {
          log.info("Cannot cleanup user relationships: " + userName + "; ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       User exoUser = getPopulatedUser(userName, session);
@@ -276,10 +278,10 @@ public class UserDAOImpl implements UserHandler
       {
          session.getPersistenceManager().removeUser(foundUser, true);
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
          log.info("Cannot remove user: " + userName + "; ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (getIntegrationCache() != null)
@@ -414,7 +416,7 @@ public class UserDAOImpl implements UserHandler
          catch (Exception e)
          {
             log.info("Cannot authenticate user: " + username + "; ",  e);
-
+            orgService.recoverFromIDMError();
          }
       }
 
@@ -602,10 +604,10 @@ public class UserDAOImpl implements UserHandler
 
          plUser = session.getAttributesManager().findUserByUniqueAttribute(USER_EMAIL, email);
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
          log.info("Cannot find user by email: " + email + "; ", e );
-
+         orgService.recoverFromIDMError();
       }
 
       User user = null;
@@ -655,7 +657,7 @@ public class UserDAOImpl implements UserHandler
       catch (Exception e)
       {
          log.info("Cannot obtain group: " + groupId + "; ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       qb.addRelatedGroup(jbidGroup);
@@ -741,10 +743,10 @@ public class UserDAOImpl implements UserHandler
             {
                am.updatePassword(session.getPersistenceManager().findUser(user.getUserName()), user.getPassword());
             }
-            catch (IdentityException e)
+            catch (Exception e)
             {
                log.info("Cannot update password: " + user.getUserName() + "; ", e);
-               throw e;
+               orgService.recoverFromIDMError();
             }
          }
       }
@@ -756,10 +758,10 @@ public class UserDAOImpl implements UserHandler
       {
          am.updateAttributes(user.getUserName(), attrs);
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
          log.info("Cannot update attributes for user: " + user.getUserName() + "; ", e);
-         throw e;
+         orgService.recoverFromIDMError();
       }
 
    }
@@ -774,10 +776,10 @@ public class UserDAOImpl implements UserHandler
       {
          u = session.getPersistenceManager().findUser(userName);
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
          log.info("Cannot obtain user: " + userName + "; ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (u == null)
@@ -805,11 +807,11 @@ public class UserDAOImpl implements UserHandler
       {
          attrs = am.getAttributes(new SimpleUser(user.getUserName()));
       }
-      catch (IdentityException e)
+      catch (Exception e)
       {
 
          log.info("Cannot obtain attributes for user: " + user.getUserName() + "; ", e);
-
+         orgService.recoverFromIDMError();
       }
 
       if (attrs == null)

--- a/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
+++ b/component/identity/src/main/java/org/exoplatform/services/organization/idm/UserProfileDAOImpl.java
@@ -160,6 +160,7 @@ public class UserProfileDAOImpl implements UserProfileHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (foundUser == null)
@@ -243,6 +244,7 @@ public class UserProfileDAOImpl implements UserProfileHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (u == null)
@@ -260,6 +262,7 @@ public class UserProfileDAOImpl implements UserProfileHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
       if (attrs == null || attrs.isEmpty())
@@ -321,6 +324,7 @@ public class UserProfileDAOImpl implements UserProfileHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
 
    }
@@ -341,6 +345,7 @@ public class UserProfileDAOImpl implements UserProfileHandler
       {
          //TODO:
          log.info("Identity operation error: ", e);
+         orgService.recoverFromIDMError();
       }
    }
 


### PR DESCRIPTION
The backport adds:
- `PicketlinkIDMOrganizationServiceImpl#recoverFromError` to handle transaction rollback and restart it if DB error occured.
- A call to this method in catch blocks of DAO services.
- Replace `IdentityException` with `Exception` in catch blocks of `UserDAOImpl` to avoid swallowing other exceptions.
